### PR TITLE
Add configuration option to ignore files (prevent them from being minified)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ config =
           DEBUG: false
 ```
 
+Joined files can be ignored and be passed-through, using 'ignored' option:
+
+```coffeeescript
+config =
+  plugins:
+    uglify:
+      ignored: /non_minimize\.js/
+
+```
+
 ## License
 
 The MIT License (MIT)

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var extend = function(object, source) {
   var value;
   for (var key in source) {
     value = source[key];
-    object[key] = (typeof value === 'object') ?
+    object[key] = (typeof value === 'object' && !(value instanceof RegExp)) ?
       (Array.isArray(value) ? value.slice() : extend({}, value)) :
       value;
   }
@@ -27,6 +27,20 @@ UglifyJSOptimizer.prototype.optimize = function(args, callback) {
   var error, optimized, data, path;
   data = args.data;
   path = args.path;
+
+  try {
+    if (this.options.ignored && this.options.ignored.test(args.path)) {
+      // ignored file path: return non minified
+      var result = {
+        data: data,
+        // It seems like brunch passes in a SourceMapGenerator object, not a string
+        map: args.map ? args.map.toString() : null
+      };
+      return callback(null, result);
+    }
+  } catch (e) {
+    return callback('error checking ignored files to uglify' + e);
+  }
 
   try {
     this.options.inSourceMap = JSON.parse(args.map);

--- a/test.js
+++ b/test.js
@@ -41,4 +41,44 @@ describe('Plugin', function() {
       done();
     });
   });
+
+  it('should ignore ignored files', function(done) {
+    plugin = new Plugin({
+      plugins: {
+        uglify: {
+          ignored: /ignoreMe\.js/
+        }
+      }
+    });
+
+    var content = '(function() {var first = 5; window.second = first;})()';
+    var expected = content;
+    var map = 'someDummyMap';
+
+    plugin.optimize({data: content, path: 'ignoreMe.js', map: map}, function(error, data) {
+      expect(error).not.to.be.ok;
+      expect(data).to.eql({data: expected, map: map});
+      done();
+    });
+
+  });
+
+  it('should not ignore non-ignored files', function(done) {
+    plugin = new Plugin({
+      plugins: {
+        uglify: {
+          ignored: /ignoreMe\.js/
+        }
+      }
+    });
+
+    var content = '(function() {var first = 5; window.second = first;})()';
+    var expected = '!function(){var n=5;window.second=n}();';
+
+    plugin.optimize({data: content, path: 'uglifyMe.js'}, function(error, data) {
+      expect(error).not.to.be.ok;
+      expect(data).to.eql({data: expected});
+      done();
+    });
+  });
 });


### PR DESCRIPTION
Some JS libraries break when minimized (see for example, https://github.com/brunch/uglify-js-brunch/issues/12), so there should be an easy (or easier) way to pass them through with no minimization. Methods such as copying to assets are breaking the use of bower, and the normal brunch flow.

This is not the most elegant solution, but better solutions might be better done at brunch, and not the specific plugin.

Suggested way of usage in config.coffee:

``` coffeescript
  files:
    javascripts:
      joinTo:
        'js/non_minimized.js': /^bower_components\/rickshaw/
        'js/app.js': /^app/
        'js/vendor.js': /^(bower_components\/(?!rickshaw)|vendor)/
#...
  plugins:
    uglify:
      ignored: /non_minimized\.js/
#...

```
